### PR TITLE
Adds use API for consistency

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,7 +1,10 @@
-const getCurrentTemperature = require('./index.js');
+var tessel = require('tessel');
+const bmpDriver = require('./index.js');
+const bmp = bmpDriver.use(tessel.port.A);
+
 
 setInterval(() => {
-  getCurrentTemperature((value) => {
+  bmp.getCurrentTemperature((value) => {
     console.log(value);
   });
 }, 1200);


### PR DESCRIPTION
@sarmadsangi I tested out your recent changes and they worked.

I went ahead and added a `use` function for consistency with other published Tessel modules. The `use` function let's you specify which Tessel port the module is attached to (and sometimes other options).